### PR TITLE
grub-core/loader/multiboot_mbi2.c: allocate event log higher

### DIFF
--- a/grub-core/loader/multiboot_mbi2.c
+++ b/grub-core/loader/multiboot_mbi2.c
@@ -405,7 +405,7 @@ grub_multiboot2_load (grub_file_t file, const char *filename)
       if (grub_relocator_alloc_chunk_align (grub_multiboot2_relocator, &ch, 0x1000000,
 					    0xffffffff - GRUB_SLAUNCH_TPM_EVT_LOG_SIZE,
 					    GRUB_SLAUNCH_TPM_EVT_LOG_SIZE, GRUB_PAGE_SIZE,
-					    GRUB_RELOCATOR_PREFERENCE_NONE, 1))
+					    GRUB_RELOCATOR_PREFERENCE_HIGH, 1))
 	{
 	  grub_free (mld.buffer);
 	  return grub_error (GRUB_ERR_OUT_OF_MEMORY, "Could not allocate TPM event log area");


### PR DESCRIPTION
On Xen AEM, with low allocation event log lands in a region that is expected to be free by dom0 kernel. Allocate it high instead.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>