### PR TITLE
i386/skinit: don't allocate TPM event log low

### DIFF
--- a/grub-core/loader/i386/skinit.c
+++ b/grub-core/loader/i386/skinit.c
@@ -106,10 +106,10 @@ grub_skinit_boot_prepare (struct grub_relocator *rel,
   if (slb == NULL)
     return grub_error (GRUB_ERR_BAD_ARGUMENT, "SLB module is missing");
 
-  err = grub_relocator_alloc_chunk_align (rel, &ch, 0x1000000,
-                                          0xffffffff - GRUB_SLAUNCH_TPM_EVT_LOG_SIZE,
-                                          GRUB_SLAUNCH_TPM_EVT_LOG_SIZE, GRUB_PAGE_SIZE,
-                                          GRUB_RELOCATOR_PREFERENCE_NONE, 1);
+  err = grub_relocator_alloc_chunk_align_safe (rel, &ch, 0x1000000,
+                                               UP_TO_TOP32(GRUB_SLAUNCH_TPM_EVT_LOG_SIZE),
+                                               GRUB_SLAUNCH_TPM_EVT_LOG_SIZE, GRUB_PAGE_SIZE,
+                                               GRUB_RELOCATOR_PREFERENCE_HIGH, 1);
 
   if (err != GRUB_ERR_NONE)
     return grub_error (err, "cannot alloc memory for TPM event log");


### PR DESCRIPTION
Do allocation in the same way as it's done for TXT (preferring high addresses), otherwise Xen loads Dom0 kernel over the TPM even log and Linux ends up panicking when it detects conflict with e820 map in Xen-specific code (why wouldn't Xen check it?  who knows).

Makes Xen in https://github.com/TrenchBoot/xen/pull/10 work.