### PR TITLE
loader/multiboot_mbi2.c: disable UEFI BS when booting with slaunch

### DIFF
--- a/grub-core/loader/multiboot_mbi2.c
+++ b/grub-core/loader/multiboot_mbi2.c
@@ -747,6 +747,12 @@ grub_multiboot2_make_mbi (grub_uint32_t *target, grub_uint32_t *size)
   grub_size_t bufsize;
   grub_relocator_chunk_t ch;
 
+  if (grub_slaunch_platform_type () != SLP_NONE)
+    {
+      /* MLE can't call pre-DLE services. */
+      keep_bs = 0;
+    }
+
   bufsize = grub_multiboot2_get_mbi_size ();
 
   COMPILE_TIME_ASSERT (MULTIBOOT_TAG_ALIGN % sizeof (grub_properly_aligned_t) == 0);


### PR DESCRIPTION
MLE (kernel or Xen) can't use pre-DLE services, as those are not measured as part of DRTM. To make sure this is true, disable boot services before MBI is created, which will ensure that all required data is obtained and saved in MBI while it is available.

BS are disabled before call to grub_multiboot2_get_mbi_size(), so the amount of allocated memory will be sufficient.