### PR TITLE
slaunch: move TPM relinquish locality call after ExitBootServices

### DIFF
--- a/grub-core/loader/slaunch/dlstub.c
+++ b/grub-core/loader/slaunch/dlstub.c
@@ -52,6 +52,8 @@ void dl_entry (grub_uint64_t dl_ctx)
 
   if (slparams->platform_type == SLP_INTEL_TXT)
     {
+      grub_tpm_relinquish_locality (0);
+
       err = grub_set_mtrrs_for_acmod ((void *)(grub_addr_t)slparams->dce_base);
       if (err)
         {

--- a/grub-core/loader/slaunch/txt.c
+++ b/grub-core/loader/slaunch/txt.c
@@ -1085,9 +1085,6 @@ grub_txt_boot_prepare (struct grub_slaunch_params *slparams)
   grub_setup_slr_table (slparams, (struct grub_slr_entry_hdr *)&slr_intel_info_staging);
   set_txt_info_ptr (slparams, os_mle_data);
 
-  grub_tpm_relinquish_locality (0);
-  grub_dprintf ("slaunch", "Relinquished TPM locality 0\n");
-
   grub_dprintf ("slaunch", "CPU prepared for secure launch\n");
 
   if (!(grub_rdmsr (GRUB_MSR_X86_APICBASE) & GRUB_MSR_X86_APICBASE_BSP))


### PR DESCRIPTION
The grub_tpm_relinquish_locality(0) must be called before starting TXT, because Intel SINIT expects no locality active.  But relinquishing it in grub_txt_boot_prepare is too early in EFI case - Linux kernel EFI stub did not run yet and it uses TPM for measured boot (non-DRTM, static root of trust).

This is fixed here by moving the call to the DL Stub.

---

Tested:
* on `grub-sl-2.12-v15` branch
* on ThinkPad X1 Carbon 5th (20HRS11400), Core i7-7600U
Fixes PCR 9 update errors shown when booting Linux with `efi=debug` and events show up in `/sys/kernel/security/tpm0/binary_bios_measurements`